### PR TITLE
Fix cross-platform includes

### DIFF
--- a/src/Utils/GridData.hpp
+++ b/src/Utils/GridData.hpp
@@ -6,7 +6,7 @@
 #include <openvdb/Types.h>
 
 #include "Memory.hpp"
-#include "typeindex"
+#include <typeindex>
 
 namespace HNS {
 

--- a/src/Utils/Memory.hpp
+++ b/src/Utils/Memory.hpp
@@ -9,12 +9,17 @@
 #include <malloc.h>
 #define _aligned_malloc(size, alignment) memalign(alignment, size)
 #define _aligned_free free
-#elif _WIN32
+#elif defined(_WIN32)
 #include <malloc.h>
-#define _aligned_malloc(size, alignment) _aligned_malloc(size, alignment)
-#define _aligned_free _aligned_free
+/* Windows provides _aligned_malloc and _aligned_free */
 #else
-
+#include <cstdlib>
+static inline void* _aligned_malloc(size_t size, size_t alignment) {
+        void* ptr = nullptr;
+        if (posix_memalign(&ptr, alignment, size) != 0) return nullptr;
+        return ptr;
+}
+static inline void _aligned_free(void* ptr) { free(ptr); }
 #endif
 
 enum class AllocationType { Standard, Aligned, CudaPinned };


### PR DESCRIPTION
## Summary
- include `<typeindex>` correctly
- improve cross-platform aligned memory helpers

## Testing
- `cmake -DHNS_BUILD_TESTS=ON ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6840141d53cc8332aa8d669851147399